### PR TITLE
Fix docs publish workflow

### DIFF
--- a/.github/workflows/generate-doc.yaml
+++ b/.github/workflows/generate-doc.yaml
@@ -3,8 +3,6 @@ name: Publish Developer Docs
 on:
   pull_request:
     types: [closed]
-    branches:
-      - main
     paths:
       - 'apps/developer-docs/**'
 


### PR DESCRIPTION
Remove `main` branch restriction, all PRs should go to main anyway.